### PR TITLE
Adjust to representation that captures whitespace more properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ categories = ["parser-implementations"]
 cookie-factory = "0.3"
 either = "1.6"
 nom = { version = "7", features = ["alloc"]}
+
+[dev-dependencies]
+pretty_assertions = "1.2.1"

--- a/tests/parse_examples.rs
+++ b/tests/parse_examples.rs
@@ -89,6 +89,7 @@ fn example13() {
 }
 
 #[test]
+// Blank node
 fn example14() {
     parse_example_file("example14.ttl");
 }
@@ -146,6 +147,7 @@ fn example23() {
 
 #[test]
 #[ignore]
+// Blank nodes + numbers
 fn example24() {
     parse_example_file("example24.ttl");
 }
@@ -158,6 +160,7 @@ fn example25() {
 
 #[test]
 #[ignore]
+// Blank nodes + numbers
 fn example26() {
     parse_example_file("example26.ttl");
 }
@@ -178,4 +181,14 @@ fn example_nested_lists() {
 // Slightly more expanded example of nested blankNodePropertyList
 fn example_nested_lists2() {
     parse_wildtype_file("nested_lists2.ttl");
+}
+
+#[test]
+fn example24_simple1() {
+    parse_wildtype_file("example24_simple1.ttl");
+}
+
+#[test]
+fn example24_simple2() {
+    parse_wildtype_file("example24_simple2.ttl");
 }

--- a/tests/parse_examples.rs
+++ b/tests/parse_examples.rs
@@ -20,8 +20,6 @@ fn parse_wildtype_file(file_name: &str) {
 }
 
 #[test]
-#[ignore]
-// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
 fn example1() {
     parse_example_file("example1.ttl");
 }

--- a/tests/parse_examples.rs
+++ b/tests/parse_examples.rs
@@ -21,7 +21,7 @@ fn parse_wildtype_file(file_name: &str) {
 
 #[test]
 #[ignore]
-// TODO: There is a comment in the middle of a statement (build custom parser for whitespace, and start treating comments as whitespace)
+// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
 fn example1() {
     parse_example_file("example1.ttl");
 }
@@ -162,6 +162,12 @@ fn example25() {
 #[ignore]
 fn example26() {
     parse_example_file("example26.ttl");
+}
+
+#[test]
+// Variant of reference example1 where "a" is replaced with "rdfs:type"
+fn example1_without_a() {
+    parse_wildtype_file("example1_without_a.ttl");
 }
 
 #[test]

--- a/tests/roundtrip_examples.rs
+++ b/tests/roundtrip_examples.rs
@@ -38,7 +38,7 @@ fn roundtrip_wildtype_file(file_name: &str) {
 
 #[test]
 #[ignore]
-// TODO: There is a comment in the middle of a statement (build custom parser for whitespace, and start treating comments as whitespace)
+// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
 fn example1() {
     roundtrip_example_file("example1.ttl");
 }
@@ -180,6 +180,12 @@ fn example25() {
 #[ignore]
 fn example26() {
     roundtrip_example_file("example26.ttl");
+}
+
+#[test]
+// Variant of reference example1 where "a" is replaced with "rdfs:type"
+fn example1_without_a() {
+    roundtrip_wildtype_file("example1_without_a.ttl");
 }
 
 #[test]

--- a/tests/roundtrip_examples.rs
+++ b/tests/roundtrip_examples.rs
@@ -37,8 +37,6 @@ fn roundtrip_wildtype_file(file_name: &str) {
 }
 
 #[test]
-#[ignore]
-// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
 fn example1() {
     roundtrip_example_file("example1.ttl");
 }

--- a/tests/roundtrip_examples.rs
+++ b/tests/roundtrip_examples.rs
@@ -1,0 +1,201 @@
+use harriet::TurtleDocument;
+use nom::error::VerboseError;
+
+fn roundtrip_example_file(file_name: &str) {
+    let input_ontology =
+        std::fs::read_to_string(&format!("./tests/reference_examples/{}", file_name)).unwrap();
+
+    let parsed = TurtleDocument::parse::<VerboseError<&str>>(&input_ontology).unwrap().1;
+
+    let mut mem: [u8; 10024] = [0; 10024];
+    let buf = &mut mem[..];
+    let (_, written_bytes) = cookie_factory::gen(
+        TurtleDocument::gen(&parsed), buf
+    )
+        .unwrap();
+    let rendered_ontology = std::str::from_utf8(&mem[..written_bytes as usize]).unwrap();
+
+    assert_eq!(input_ontology, rendered_ontology);
+}
+
+fn roundtrip_wildtype_file(file_name: &str) {
+    let input_ontology =
+        std::fs::read_to_string(&format!("./tests/wildtype_examples/{}", file_name)).unwrap();
+
+    let parsed = TurtleDocument::parse::<VerboseError<&str>>(&input_ontology).unwrap().1;
+
+    let mut mem: [u8; 10024] = [0; 10024];
+    let buf = &mut mem[..];
+    let (_, written_bytes) = cookie_factory::gen(
+        TurtleDocument::gen(&parsed), buf
+    )
+        .unwrap();
+    let rendered_ontology = std::str::from_utf8(&mem[..written_bytes as usize]).unwrap();
+
+    assert_eq!(input_ontology, rendered_ontology);
+}
+
+#[test]
+#[ignore]
+// TODO: There is a comment in the middle of a statement (build custom parser for whitespace, and start treating comments as whitespace)
+fn example1() {
+    roundtrip_example_file("example1.ttl");
+}
+
+#[test]
+fn example2() {
+    roundtrip_example_file("example2.ttl");
+}
+
+#[test]
+#[ignore]
+fn example3() {
+    roundtrip_example_file("example3.ttl");
+}
+
+#[test]
+fn example4() {
+    roundtrip_example_file("example4.ttl");
+}
+
+#[test]
+#[ignore]
+fn example5() {
+    roundtrip_example_file("example5.ttl");
+}
+
+#[test]
+fn example6() {
+    roundtrip_example_file("example6.ttl");
+}
+
+#[test]
+fn example7() {
+    roundtrip_example_file("example7.ttl");
+}
+
+#[test]
+fn example8() {
+    roundtrip_example_file("example8.ttl");
+}
+
+#[test]
+#[ignore]
+// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
+fn example9() {
+    roundtrip_example_file("example9.ttl");
+}
+
+#[test]
+fn example10() {
+    roundtrip_example_file("example10.ttl");
+}
+
+#[test]
+fn example11() {
+    roundtrip_example_file("example11.ttl");
+}
+
+#[test]
+#[ignore]
+// Number literals
+fn example12() {
+    roundtrip_example_file("example12.ttl");
+}
+
+#[test]
+#[ignore]
+fn example13() {
+    roundtrip_example_file("example13.ttl");
+}
+
+#[test]
+fn example14() {
+    roundtrip_example_file("example14.ttl");
+}
+
+#[test]
+#[ignore]
+fn example15() {
+    roundtrip_example_file("example15.ttl");
+}
+
+#[test]
+#[ignore]
+fn example16() {
+    roundtrip_example_file("example16.ttl");
+}
+
+#[test]
+fn example17() {
+    roundtrip_example_file("example17.ttl");
+}
+
+#[test]
+#[ignore]
+fn example18() {
+    roundtrip_example_file("example18.ttl");
+}
+
+#[test]
+#[ignore]
+fn example19() {
+    roundtrip_example_file("example19.ttl");
+}
+
+#[test]
+#[ignore]
+fn example20() {
+    roundtrip_example_file("example20.ttl");
+}
+
+#[test]
+#[ignore]
+fn example21() {
+    roundtrip_example_file("example21.ttl");
+}
+
+#[test]
+#[ignore]
+// Multiline string in a single line via \n escape sequence
+fn example22() {
+    roundtrip_example_file("example22.ttl");
+}
+
+#[test]
+#[ignore]
+fn example23() {
+    roundtrip_example_file("example23.ttl");
+}
+
+#[test]
+#[ignore]
+fn example24() {
+    roundtrip_example_file("example24.ttl");
+}
+
+#[test]
+#[ignore]
+fn example25() {
+    roundtrip_example_file("example25.ttl");
+}
+
+#[test]
+#[ignore]
+fn example26() {
+    roundtrip_example_file("example26.ttl");
+}
+
+#[test]
+#[ignore]
+// Trimmed down example of nested blankNodePropertyList
+fn example_nested_lists() {
+    roundtrip_wildtype_file("nested_lists.ttl");
+}
+
+#[test]
+#[ignore]
+// Slightly more expanded example of nested blankNodePropertyList
+fn example_nested_lists2() {
+    roundtrip_wildtype_file("nested_lists2.ttl");
+}

--- a/tests/roundtrip_examples.rs
+++ b/tests/roundtrip_examples.rs
@@ -198,3 +198,13 @@ fn example_nested_lists() {
 fn example_nested_lists2() {
     roundtrip_wildtype_file("nested_lists2.ttl");
 }
+
+#[test]
+fn example24_simple1() {
+    roundtrip_wildtype_file("example24_simple1.ttl");
+}
+
+#[test]
+fn example24_simple2() {
+    roundtrip_wildtype_file("example24_simple2.ttl");
+}

--- a/tests/roundtrip_examples.rs
+++ b/tests/roundtrip_examples.rs
@@ -1,5 +1,6 @@
 use harriet::TurtleDocument;
 use nom::error::VerboseError;
+use pretty_assertions::{assert_eq};
 
 fn roundtrip_example_file(file_name: &str) {
     let input_ontology =
@@ -48,7 +49,6 @@ fn example2() {
 }
 
 #[test]
-#[ignore]
 fn example3() {
     roundtrip_example_file("example3.ttl");
 }
@@ -59,7 +59,6 @@ fn example4() {
 }
 
 #[test]
-#[ignore]
 fn example5() {
     roundtrip_example_file("example5.ttl");
 }
@@ -104,7 +103,6 @@ fn example12() {
 }
 
 #[test]
-#[ignore]
 fn example13() {
     roundtrip_example_file("example13.ttl");
 }
@@ -138,7 +136,6 @@ fn example18() {
 }
 
 #[test]
-#[ignore]
 fn example19() {
     roundtrip_example_file("example19.ttl");
 }
@@ -150,7 +147,6 @@ fn example20() {
 }
 
 #[test]
-#[ignore]
 fn example21() {
     roundtrip_example_file("example21.ttl");
 }
@@ -187,7 +183,6 @@ fn example26() {
 }
 
 #[test]
-#[ignore]
 // Trimmed down example of nested blankNodePropertyList
 fn example_nested_lists() {
     roundtrip_wildtype_file("nested_lists.ttl");

--- a/tests/wildtype_examples/example1_without_a.ttl
+++ b/tests/wildtype_examples/example1_without_a.ttl
@@ -1,0 +1,15 @@
+@base <http://example.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://www.perceive.net/schemas/relationship/> .
+
+<#green-goblin>
+    rel:enemyOf <#spiderman> ;
+    rdfs:type foaf:Person ;    # in the context of the Marvel universe
+    foaf:name "Green Goblin" .
+
+<#spiderman>
+    rel:enemyOf <#green-goblin> ;
+    rdfs:type foaf:Person ;
+    foaf:name "Spiderman", "Человек-паук"@ru .

--- a/tests/wildtype_examples/example24_simple1.ttl
+++ b/tests/wildtype_examples/example24_simple1.ttl
@@ -1,0 +1,2 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    _:b0  rdf:first  rdf:other .

--- a/tests/wildtype_examples/example24_simple2.ttl
+++ b/tests/wildtype_examples/example24_simple2.ttl
@@ -1,0 +1,2 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    _:b0  rdf:first  _:0other .


### PR DESCRIPTION
- Try to parse whitespace properly, to properly fully represent a Turtle document for non-destructive editing
- Adds roundtrip tests that ensure that rendering a previously parsed file results in an identical file
- Add support for `Verb`
- Add support for `BlankNode`