### PR TITLE
Implement TripleProducer with support for IRI-only triples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ cookie-factory = "0.3"
 either = "1.6"
 nom = { version = "7", features = ["alloc"]}
 anyhow = "1"
+snowflake = "1"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["parser-implementations"]
 cookie-factory = "0.3"
 either = "1.6"
 nom = { version = "7", features = ["alloc"]}
+anyhow = "1"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/examples/triples.rs
+++ b/examples/triples.rs
@@ -1,0 +1,13 @@
+use harriet::TurtleDocument;
+use harriet::triple_production::TripleProducer;
+
+pub fn main() {
+    let ontology = std::fs::read_to_string(
+        &std::env::args()
+            .nth(1)
+            .expect("Expected path to .ttl file as first argument"),
+    )
+    .unwrap();
+    let document = TurtleDocument::parse_full(&ontology).unwrap();
+    dbg!(TripleProducer::produce_for_document(&document));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+pub mod triple_production;
+
 use crate::ParseError::NotFullyParsed;
 use cookie_factory::combinator::string as cf_string;
 use cookie_factory::lib::std::io::Write;
@@ -19,7 +21,7 @@ use std::borrow::Cow;
 use std::borrow::Cow::Borrowed;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TurtleDocument<'a> {
     pub statements: Vec<Statement<'a>>,
     pub trailing_whitespace: Option<Whitespace<'a>>,
@@ -77,7 +79,7 @@ impl ToString for TurtleDocument<'_> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement<'a> {
     Directive(Directive<'a>),
     Triples(Triples<'a>),
@@ -163,7 +165,7 @@ impl<'a> Whitespace<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Triples<'a> {
     Labeled(Option<Whitespace<'a>>, Subject<'a>, PredicateObjectList<'a>),
     // Labeled()
@@ -206,7 +208,7 @@ impl<'a> Triples<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Subject<'a> {
     IRI(IRI<'a>),
     BlankNode(BlankNode<'a>),
@@ -235,7 +237,7 @@ impl<'a> Subject<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// A "Verb" can be used for inside a [PredicateObjectList]. It allows for using the character 'a'
 /// as a placeholder for `rdfs:type`.
 ///
@@ -267,7 +269,7 @@ impl<'a> From<IRI<'a>> for Verb<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IRI<'a> {
     IRIReference(IRIReference<'a>),
     PrefixedName(PrefixedName<'a>),
@@ -410,7 +412,7 @@ impl<'a> BlankNodeAnonymous<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PredicateObjectList<'a> {
     pub list: Vec<(
         Whitespace<'a>,
@@ -473,7 +475,7 @@ impl<'a> PredicateObjectList<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlankNodePropertyList<'a> {
     pub list: PredicateObjectList<'a>,
     pub trailing_whitespace: Option<Whitespace<'a>>,
@@ -518,7 +520,7 @@ impl<'a> BlankNodePropertyList<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectList<'a> {
     pub list: Vec<(
         // Whitespace before separator (will be None on first element)
@@ -582,7 +584,7 @@ impl<'a> ObjectList<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Object<'a> {
     IRI(IRI<'a>),
     BlankNode(BlankNode<'a>),
@@ -617,7 +619,7 @@ impl<'a> Object<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Collection<'a> {
     pub list: Vec<Object<'a>>,
 }
@@ -979,7 +981,7 @@ impl<'a> PrefixedName<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Literal<'a> {
     RDFLiteral(RDFLiteral<'a>),
     NumericLiteral(NumericLiteral<'a>),
@@ -1007,7 +1009,7 @@ impl<'a> Literal<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RDFLiteral<'a> {
     pub string: TurtleString<'a>,
     pub language_tag: Option<Cow<'a, str>>,
@@ -1085,7 +1087,7 @@ impl<'a> RDFLiteral<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NumericLiteral<'a> {
     Integer(Integer<'a>),
     // Decimal(Decimal<'a>),
@@ -1113,7 +1115,7 @@ impl<'a> NumericLiteral<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Integer<'a> {
     pub sign: Option<Cow<'a, str>>,
     pub number_literal: Cow<'a, str>,
@@ -1152,17 +1154,17 @@ impl<'a> Integer<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Decimal<'a> {
     pub string: Cow<'a, str>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Double<'a> {
     pub string: Cow<'a, str>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BooleanLiteral {
     pub bool: bool,
 }
@@ -1186,7 +1188,7 @@ impl BooleanLiteral {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TurtleString<'a> {
     StringLiteralQuote(StringLiteralQuote<'a>),
     StringLiteralSingleQuote(StringLiteralSingleQuote<'a>),
@@ -1238,7 +1240,7 @@ impl<'a> ToString for TurtleString<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringLiteralQuote<'a> {
     pub string: Cow<'a, str>,
 }
@@ -1281,7 +1283,7 @@ impl<'a> StringLiteralQuote<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringLiteralSingleQuote<'a> {
     pub string: Cow<'a, str>,
 }
@@ -1325,7 +1327,7 @@ impl<'a> StringLiteralSingleQuote<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringLiteralLongQuote<'a> {
     pub string: Cow<'a, str>,
 }
@@ -1360,7 +1362,7 @@ impl<'a> StringLiteralLongQuote<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringLiteralLongSingleQuote<'a> {
     pub string: Cow<'a, str>,
 }

--- a/src/triple_production.rs
+++ b/src/triple_production.rs
@@ -1,0 +1,221 @@
+use crate::{
+    Directive, IRIReference, Object, Statement, Subject, Triples, TurtleDocument, Verb, IRI,
+};
+use anyhow::{anyhow, Context, Error};
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+/// A triple producer, produces is able to produce a stream of RDF Triples based on a parsed Turtle document.
+///
+/// See <https://www.w3.org/TR/turtle/#sec-parsing>
+#[derive(Debug)]
+pub struct TripleProducer;
+
+#[derive(Debug, Default)]
+struct ProducerState<'a> {
+    /// Tracks the current base URI.
+    base_uri: Option<String>,
+    /// Tracks the current namespaces (= prefix to prefix-URI mapping).
+    namespaces: HashMap<String, String>,
+    /// Tracks the current set of blank node labels.
+    blank_node_labels: HashMap<String, RdfBlankNode>,
+    /// Tracks the current production subject.
+    current_subject: Option<RdfSubject<'a>>,
+    /// Tracks the current production predicate.
+    current_predicate: Option<RdfPredicate<'a>>,
+}
+
+impl TripleProducer {
+    pub fn produce_for_document<'a>(
+        document: &TurtleDocument<'a>,
+    ) -> Result<Vec<RdfTriple<'a>>, Error> {
+        let mut state = ProducerState::default();
+        let mut triples: Vec<RdfTriple> = vec![];
+
+        for statement in document.statements.clone() {
+            match statement {
+                Statement::Directive(directive) => state.apply_directive(directive),
+                Statement::Triples(stmt_triples) => {
+                    // Reset the subject; Shouldn't be necessary, but maybe keeps a few bugs out.
+                    state.current_subject = None;
+                    state.current_predicate = None;
+                    match stmt_triples {
+                        Triples::Labeled(_, subject, predicate_object_list) => {
+                            match subject {
+                                Subject::IRI(iri) => state
+                                    .set_current_subject(RdfSubject::IRI(state.convert_iri(iri)?)),
+                                Subject::BlankNode(_) => {
+                                    // TODO
+                                    Err(anyhow!(
+                                        "BlankNodes are not supported in TripleProducer yet."
+                                    ))?;
+                                }
+                                Subject::Collection(_) => {
+                                    // TODO
+                                    Err(anyhow!(
+                                        "Collections are not supported in TripleProducer yet."
+                                    ))?;
+                                }
+                            }
+                            for (_, verb, object_list, _) in predicate_object_list.list {
+                                state.set_current_predicate(state.convert_verb(verb)?);
+                                for (_, _, object) in object_list.list {
+                                    match object {
+                                        Object::IRI(iri) => state.produce_triple(
+                                            &mut triples,
+                                            RdfObject::IRI(state.convert_iri(iri)?),
+                                        )?,
+                                        Object::Literal(_) => {}
+                                        Object::BlankNode(_) => {}
+                                        Object::Collection(_) => {}
+                                        Object::BlankNodePropertyList(_) => {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(triples)
+    }
+}
+
+impl<'a> ProducerState<'a> {
+    fn set_base_uri<U: Into<String>>(&mut self, base_uri: U) {
+        self.base_uri = Some(base_uri.into());
+    }
+
+    fn set_namespace<P: Into<String>, U: Into<String>>(&mut self, prefix: P, uri: U) {
+        self.namespaces.insert(prefix.into(), uri.into());
+    }
+
+    fn set_current_subject<S: Into<RdfSubject<'a>>>(&mut self, subject: S) {
+        self.current_subject = Some(subject.into())
+    }
+
+    fn set_current_predicate<P: Into<RdfPredicate<'a>>>(&mut self, predicate: P) {
+        self.current_predicate = Some(predicate.into())
+    }
+
+    fn apply_directive(&mut self, directive: Directive) {
+        match directive {
+            Directive::Base(base_dir) => self.set_base_uri(base_dir.iri.iri),
+            Directive::SparqlBase(base_dir) => self.set_base_uri(base_dir.iri.iri),
+            Directive::Prefix(prefix_dir) => self.set_namespace(
+                prefix_dir.prefix.unwrap_or(Cow::Borrowed("")),
+                prefix_dir.iri.iri,
+            ),
+            Directive::SparqlPrefix(prefix_dir) => self.set_namespace(
+                prefix_dir.prefix.unwrap_or(Cow::Borrowed("")),
+                prefix_dir.iri.iri,
+            ),
+        }
+    }
+
+    fn produce_triple<O: Into<RdfObject<'a>>>(
+        &self,
+        triples: &mut Vec<RdfTriple<'a>>,
+        object: O,
+    ) -> Result<(), Error> {
+        let triple = RdfTriple {
+            subject: self
+                .current_subject
+                .clone()
+                .context("Trying to produce triple without current subject")?,
+            predicate: self
+                .current_predicate
+                .clone()
+                .context("Trying to produce triple without current predicate")?,
+            object: object.into(),
+        };
+        triples.push(triple);
+        Ok(())
+    }
+
+    fn convert_iri(&self, iri: IRI<'a>) -> Result<RdfIri<'a>, Error> {
+        Ok(match iri {
+            IRI::IRIReference(iri_ref) => RdfIri {
+                iri: self.resolve_iri(iri_ref),
+            },
+            IRI::PrefixedName(prefixed_name) => RdfIri {
+                iri: format!(
+                    "{prefix}{local_name}",
+                    prefix = self.resolve_prefix(prefixed_name.prefix.as_deref())?,
+                    local_name = prefixed_name
+                        .name
+                        .context("Empty local_name part of PrefixedName")?
+                )
+                .into(),
+            },
+        })
+    }
+
+    fn convert_verb(&self, verb: Verb<'a>) -> Result<RdfPredicate<'a>, Error> {
+        Ok(match verb {
+            Verb::A => {
+                // TODO: implement
+                Err(anyhow!("Conversion of `a` verb not implemented yet."))?
+            }
+            Verb::IRI(iri) => RdfPredicate::IRI(self.convert_iri(iri)?),
+        })
+    }
+
+    // TODO: resolution of relative IRIs relative to the base
+    // See https://www.ietf.org/rfc/rfc3986.txt - Section 5.2 - Requires parsing the base and the iri
+    fn resolve_iri(&self, iri_ref: IRIReference<'a>) -> Cow<'a, str> {
+        match &self.base_uri {
+            None => iri_ref.iri,
+            Some(base) => format!("{base}{relative_iri}", relative_iri = iri_ref.iri).into(),
+        }
+    }
+
+    fn resolve_prefix(&self, prefix: Option<&str>) -> Result<&String, Error> {
+        self.namespaces
+            .get(prefix.unwrap_or(""))
+            .context("Unable to resolve prefix `{prefix}`")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RdfTriple<'a> {
+    pub subject: RdfSubject<'a>,
+    pub predicate: RdfPredicate<'a>,
+    pub object: RdfObject<'a>,
+}
+
+#[derive(Debug, Clone)]
+pub enum RdfSubject<'a> {
+    IRI(RdfIri<'a>),
+    BlankNode(RdfBlankNode),
+}
+
+#[derive(Debug, Clone)]
+pub enum RdfPredicate<'a> {
+    IRI(RdfIri<'a>),
+}
+
+#[derive(Debug, Clone)]
+pub enum RdfObject<'a> {
+    IRI(RdfIri<'a>),
+    BlankNode(RdfBlankNode),
+    Literal(RdfLiteral<'a>),
+}
+
+#[derive(Debug, Clone)]
+pub struct RdfIri<'a> {
+    pub iri: Cow<'a, str>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RdfLiteral<'a> {
+    pub lexical_form: Cow<'a, str>,
+    pub datatype_iri: Cow<'a, str>,
+    pub language_tag: Option<Cow<'a, str>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RdfBlankNode {
+    internal_id: u32,
+}

--- a/src/triple_production.rs
+++ b/src/triple_production.rs
@@ -1,8 +1,9 @@
-use crate::{BlankNode, BlankNodeLabel, Directive, IRIReference, Object, Statement, Subject, Triples, TurtleDocument, Verb, IRI, Literal};
-use anyhow::{anyhow, Context, Error};
+use crate::{BlankNode, BlankNodeLabel, Directive, IRIReference, Literal, Object, PredicateObjectList, Statement, Subject, Triples, TurtleDocument, Verb, IRI, Collection};
+use anyhow::{anyhow, bail, Context, Error};
 use snowflake::ProcessUniqueId;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use either::Either;
 
 /// A triple producer, produces is able to produce a stream of RDF Triples based on a parsed Turtle document.
 ///
@@ -61,61 +62,11 @@ impl TripleProducer {
                                     ))?;
                                 }
                             }
-                            for (_, verb, object_list, _) in predicate_object_list.list {
-                                state.set_current_predicate(state.convert_verb(verb)?);
-                                for (_, _, object) in object_list.list {
-                                    match object {
-                                        Object::IRI(iri) => state.produce_triple(
-                                            &mut triples,
-                                            RdfObject::IRI(state.convert_iri(iri)?),
-                                        )?,
-                                        Object::Literal(literal) => {
-                                            match literal {
-                                                Literal::RDFLiteral(rdf_literal) => {
-                                                    // TODO: handle implied datatype iris
-                                                    state.produce_triple(&mut triples, RdfObject::Literal(RdfLiteral {
-                                                        lexical_form: Cow::Owned(rdf_literal.string.to_string()),
-                                                        datatype_iri: rdf_literal.iri.map(|n| state.convert_iri(n)).transpose()?,
-                                                        // TODO: language tag
-                                                        language_tag: None
-                                                    }))?;
-                                                }
-                                                Literal::BooleanLiteral(_) => {
-                                                    Err(anyhow!(
-                                                "Boolean Literal not supported in TripleProducer yet."
-                                            ))?;
-                                                }
-                                            }
-                                        }
-                                        Object::BlankNode(blank_node) => {
-                                            let current_blank_node = match blank_node {
-                                                BlankNode::Anonymous(_) => {
-                                                    state.allocate_blank_node()
-                                                }
-                                                BlankNode::Labeled(labled) => {
-                                                    state.allocate_labeled_blank_node(labled)
-                                                }
-                                            };
-                                            state.produce_triple(
-                                                &mut triples,
-                                                RdfObject::BlankNode(current_blank_node),
-                                            )?;
-                                        }
-                                        Object::Collection(_) => {
-                                            // TODO
-                                            Err(anyhow!(
-                                                "Collection not supported in TripleProducer yet."
-                                            ))?;
-                                        }
-                                        Object::BlankNodePropertyList(_) => {
-                                            // TODO
-                                            Err(anyhow!(
-                                                "BlankNodePropertyList not supported in TripleProducer yet."
-                                            ))?;
-                                        }
-                                    }
-                                }
-                            }
+                            Self::produce_predicate_object_list(
+                                &mut state,
+                                &mut triples,
+                                predicate_object_list,
+                            )?;
                         }
                     }
                 }
@@ -123,6 +74,134 @@ impl TripleProducer {
         }
 
         Ok(triples)
+    }
+
+    fn produce_predicate_object_list<'a>(
+        state: &mut ProducerState<'a>,
+        mut triples: &mut Vec<RdfTriple<'a>>,
+        predicate_object_list: PredicateObjectList<'a>,
+    ) -> Result<(), Error> {
+        for (_, verb, object_list, _) in predicate_object_list.list {
+            state.set_current_predicate(state.convert_verb(verb)?);
+            for (_, _, object) in object_list.list {
+                let rdf_object = Self::produce_object(state, triples, object)?;
+                state.produce_triple(&mut triples, rdf_object)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn produce_object<'a>(
+        state: &mut ProducerState<'a>,
+        mut triples: &mut Vec<RdfTriple<'a>>,
+        object: Object<'a>,
+    ) -> Result<RdfObject<'a>, Error> {
+        Ok(match object {
+            Object::IRI(iri) => RdfObject::IRI(state.convert_iri(iri)?),
+            Object::Literal(literal) => {
+                match literal {
+                    Literal::RDFLiteral(rdf_literal) => {
+                        RdfObject::Literal(RdfLiteral {
+                            lexical_form: Cow::Owned(rdf_literal.string.to_string()),
+                            datatype_iri: rdf_literal
+                                .iri
+                                .map(|n| state.convert_iri(n))
+                                .transpose()?,
+                            // TODO: language tag
+                            language_tag: None,
+                        })
+                    }
+                    Literal::BooleanLiteral(_) => {
+                        bail!("Boolean Literal not supported in TripleProducer yet.")
+                    }
+                    Literal::NumericLiteral(_) => {
+                        bail!("Numeric Literal not supported in TripleProducer yet.")
+                    }
+                }
+            }
+            Object::BlankNode(blank_node) => {
+                let current_blank_node = match blank_node {
+                    BlankNode::Anonymous(_) => state.allocate_blank_node(),
+                    BlankNode::Labeled(labled) => state.allocate_labeled_blank_node(labled),
+                };
+                RdfObject::BlankNode(current_blank_node)
+            }
+            Object::Collection(collection) => {
+                match Self::produce_collection(state, triples, collection)? {
+                    Either::Left(iri) => { RdfObject::IRI(iri)}
+                    Either::Right(blank_node) => {RdfObject::BlankNode(blank_node)}
+                }
+            }
+            Object::BlankNodePropertyList(blank_node_property_list) => {
+                let mut sub_triples = vec![];
+
+                let blank_node = state.allocate_blank_node();
+
+                let stashed_subject = state.current_subject.clone();
+                let stashed_predicate = state.current_predicate.clone();
+
+                state.set_current_subject(RdfSubject::BlankNode(blank_node.clone()));
+
+                Self::produce_predicate_object_list(
+                    state,
+                    &mut sub_triples,
+                    blank_node_property_list.list,
+                )?;
+
+                state.current_subject = stashed_subject;
+                state.current_predicate = stashed_predicate;
+
+                triples.append(&mut sub_triples);
+
+                RdfObject::BlankNode(blank_node.clone())
+            }
+        })
+    }
+
+    /// See <https://www.w3.org/TR/turtle/#collection>
+    fn produce_collection<'a>(
+        state: &mut ProducerState<'a>,
+        mut triples: &mut Vec<RdfTriple<'a>>,
+        collection: Collection<'a>,
+    ) -> Result<Either<RdfIri<'a>, RdfBlankNode>, Error> {
+        let stashed_subject = state.current_subject.clone();
+        let stashed_predicate = state.current_predicate.clone();
+
+        let return_node = match collection.list.len() {
+            0 => Either::Left(iri_constants::RDF_NIL),
+            _ => {
+                let mut first_blank_node: Option<RdfBlankNode> = None;
+
+                let mut previous_blank_node = None;
+                for object in collection.list {
+                    let current_blank_node = state.allocate_blank_node();
+                    if matches!(first_blank_node, None) {
+                        first_blank_node = Some(current_blank_node.clone());
+                    }
+                    if let Some(_) = previous_blank_node {
+                        state.set_current_predicate(RdfPredicate::IRI(iri_constants::RDF_REST));
+                        state.produce_triple(triples, RdfObject::BlankNode(current_blank_node.clone()));
+                    }
+
+                    state.set_current_subject(RdfSubject::BlankNode(current_blank_node.clone()));
+                    state.set_current_predicate(RdfPredicate::IRI(iri_constants::RDF_FIRST));
+
+                    let rdf_object = Self::produce_object(state, triples, object)?;
+                    state.produce_triple(triples, rdf_object)?;
+
+                    previous_blank_node = Some(current_blank_node.clone());
+                }
+                state.set_current_predicate(RdfPredicate::IRI(iri_constants::RDF_REST));
+                state.produce_triple(triples, RdfObject::IRI(iri_constants::RDF_NIL));
+
+                Either::Right(first_blank_node.expect("Tried to produce collection without returning a blank node"))
+            }
+        };
+
+        state.current_subject = stashed_subject;
+        state.current_predicate = stashed_predicate;
+
+        Ok(return_node)
     }
 }
 
@@ -211,9 +290,7 @@ impl<'a> ProducerState<'a> {
 
     fn convert_verb(&self, verb: Verb<'a>) -> Result<RdfPredicate<'a>, Error> {
         Ok(match verb {
-            Verb::A => {
-                RdfPredicate::IRI(iri_constants::RDF_TYPE)
-            }
+            Verb::A => RdfPredicate::IRI(iri_constants::RDF_TYPE),
             Verb::IRI(iri) => RdfPredicate::IRI(self.convert_iri(iri)?),
         })
     }
@@ -285,10 +362,22 @@ impl RdfBlankNode {
 }
 
 mod iri_constants {
-    use std::borrow::Cow;
     use crate::triple_production::RdfIri;
+    use std::borrow::Cow;
 
     pub const RDF_TYPE: RdfIri = RdfIri {
-        iri: Cow::Borrowed("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        iri: Cow::Borrowed("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+    };
+
+    pub const RDF_FIRST: RdfIri = RdfIri {
+        iri: Cow::Borrowed("http://www.w3.org/1999/02/22-rdf-syntax-ns#first"),
+    };
+
+    pub const RDF_REST: RdfIri = RdfIri {
+        iri: Cow::Borrowed("http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"),
+    };
+
+    pub const RDF_NIL: RdfIri = RdfIri {
+        iri: Cow::Borrowed("http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"),
     };
 }

--- a/tests/triple_production_examples.rs
+++ b/tests/triple_production_examples.rs
@@ -122,13 +122,11 @@ fn example19() {
 }
 
 #[test]
-#[ignore]
 fn example20() {
     triples_example_file("example20.ttl");
 }
 
 #[test]
-#[ignore]
 fn example21() {
     triples_example_file("example21.ttl");
 }

--- a/tests/triple_production_examples.rs
+++ b/tests/triple_production_examples.rs
@@ -1,0 +1,197 @@
+use harriet::TurtleDocument;
+use nom::error::VerboseError;
+use harriet::triple_production::TripleProducer;
+
+fn triples_example_file(file_name: &str) {
+    let ontology =
+        std::fs::read_to_string(&format!("./tests/reference_examples/{}", file_name)).unwrap();
+    let document = TurtleDocument::parse_full(&ontology).unwrap();
+    assert!(dbg!(TripleProducer::produce_for_document(&document)).is_ok());
+}
+
+fn triples_wildtype_file(file_name: &str) {
+    let ontology =
+        std::fs::read_to_string(&format!("./tests/wildtype_examples/{}", file_name)).unwrap();
+    let document = TurtleDocument::parse_full(&ontology).unwrap();
+    assert!(dbg!(TripleProducer::produce_for_document(&document)).is_ok());
+}
+
+#[test]
+fn example1() {
+    triples_example_file("example1.ttl");
+}
+
+#[test]
+fn example2() {
+    triples_example_file("example2.ttl");
+}
+
+#[test]
+fn example3() {
+    triples_example_file("example3.ttl");
+}
+
+#[test]
+fn example4() {
+    triples_example_file("example4.ttl");
+}
+
+#[test]
+fn example5() {
+    triples_example_file("example5.ttl");
+}
+
+#[test]
+fn example6() {
+    triples_example_file("example6.ttl");
+}
+
+#[test]
+fn example7() {
+    triples_example_file("example7.ttl");
+}
+
+#[test]
+fn example8() {
+    triples_example_file("example8.ttl");
+}
+
+#[test]
+#[ignore]
+// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
+fn example9() {
+    triples_example_file("example9.ttl");
+}
+
+#[test]
+fn example10() {
+    triples_example_file("example10.ttl");
+}
+
+#[test]
+fn example11() {
+    triples_example_file("example11.ttl");
+}
+
+#[test]
+#[ignore]
+// Number literals
+fn example12() {
+    triples_example_file("example12.ttl");
+}
+
+#[test]
+#[ignore]
+fn example13() {
+    triples_example_file("example13.ttl");
+}
+
+#[test]
+// Blank node
+fn example14() {
+    triples_example_file("example14.ttl");
+}
+
+#[test]
+#[ignore]
+fn example15() {
+    triples_example_file("example15.ttl");
+}
+
+#[test]
+#[ignore]
+fn example16() {
+    triples_example_file("example16.ttl");
+}
+
+#[test]
+fn example17() {
+    triples_example_file("example17.ttl");
+}
+
+#[test]
+#[ignore]
+fn example18() {
+    triples_example_file("example18.ttl");
+}
+
+#[test]
+#[ignore]
+fn example19() {
+    triples_example_file("example19.ttl");
+}
+
+#[test]
+#[ignore]
+fn example20() {
+    triples_example_file("example20.ttl");
+}
+
+#[test]
+#[ignore]
+fn example21() {
+    triples_example_file("example21.ttl");
+}
+
+#[test]
+#[ignore]
+// Multiline string in a single line via \n escape sequence
+fn example22() {
+    triples_example_file("example22.ttl");
+}
+
+#[test]
+#[ignore]
+fn example23() {
+    triples_example_file("example23.ttl");
+}
+
+#[test]
+#[ignore]
+// Blank nodes + numbers
+fn example24() {
+    triples_example_file("example24.ttl");
+}
+
+#[test]
+#[ignore]
+fn example25() {
+    triples_example_file("example25.ttl");
+}
+
+#[test]
+#[ignore]
+// Blank nodes + numbers
+fn example26() {
+    triples_example_file("example26.ttl");
+}
+
+#[test]
+// Variant of reference example1 where "a" is replaced with "rdfs:type"
+fn example1_without_a() {
+    triples_wildtype_file("example1_without_a.ttl");
+}
+
+#[test]
+#[ignore]
+// Trimmed down example of nested blankNodePropertyList
+fn example_nested_lists() {
+    triples_wildtype_file("nested_lists.ttl");
+}
+
+#[test]
+#[ignore]
+// Slightly more expanded example of nested blankNodePropertyList
+fn example_nested_lists2() {
+    triples_wildtype_file("nested_lists2.ttl");
+}
+
+#[test]
+fn example24_simple1() {
+    triples_wildtype_file("example24_simple1.ttl");
+}
+
+#[test]
+fn example24_simple2() {
+    triples_wildtype_file("example24_simple2.ttl");
+}


### PR DESCRIPTION
- Implements a `TripleProducer` that produces a set of triples for a parsed document

## Open TODOs

- [x] Set up testing against reference examples, to make sure that we can emit everything we can parse without errors
- [ ] Implement production of everything we can parse so far
  - [ ] Implement relative IRI resolution algorithm (maybe there is a crate for that?)

CLOSES #4 