### PR TITLE
Add tests for leading whitespace

### DIFF
--- a/tests/parse_examples.rs
+++ b/tests/parse_examples.rs
@@ -1,4 +1,4 @@
-use harriet::TurtleDocument;
+use harriet::{Directive, Statement, TurtleDocument};
 use nom::error::VerboseError;
 
 fn parse_example_file(file_name: &str) {
@@ -206,4 +206,21 @@ fn example24_simple1() {
 #[test]
 fn example24_simple2() {
     parse_wildtype_file("example24_simple2.ttl");
+}
+
+#[test]
+fn leading_whitespace_base() {
+    let file_name = "leading_whitespace_base.ttl";
+    let ontology =
+        std::fs::read_to_string(&format!("./tests/wildtype_examples/{}", file_name)).unwrap();
+    let document = TurtleDocument::parse::<VerboseError<&str>>(&ontology)
+        .unwrap()
+        .1;
+    let mut count = 0;
+    for statement in document.statements {
+        if let Statement::Directive(Directive::Base(_)) = statement {
+            count += 1;
+        }
+    }
+    assert_eq!(1, count);
 }

--- a/tests/wildtype_examples/leading_whitespace_base.ttl
+++ b/tests/wildtype_examples/leading_whitespace_base.ttl
@@ -1,0 +1,3 @@
+
+@base <http://example.org/elements> .
+@prefix : <http://example.org/elements> .

--- a/tests/wildtype_examples/leading_whitespace_prefix.ttl
+++ b/tests/wildtype_examples/leading_whitespace_prefix.ttl
@@ -1,0 +1,3 @@
+
+@prefix : <http://example.org/elements> .
+@base <http://example.org/elements> .


### PR DESCRIPTION
Adds tests for the issues in #10. As I don't remember the exact steps to reproduce it, I'll have to assume that the issue was due to using an older version of harriet.