### PR TITLE
Fix leading whitespace support for SPARQL base/prefix

### DIFF
--- a/tests/parse_examples.rs
+++ b/tests/parse_examples.rs
@@ -60,8 +60,6 @@ fn example8() {
 }
 
 #[test]
-#[ignore]
-// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
 fn example9() {
     parse_example_file("example9.ttl");
 }

--- a/tests/roundtrip_examples.rs
+++ b/tests/roundtrip_examples.rs
@@ -77,8 +77,6 @@ fn example8() {
 }
 
 #[test]
-#[ignore]
-// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
 fn example9() {
     roundtrip_example_file("example9.ttl");
 }

--- a/tests/triple_production_examples.rs
+++ b/tests/triple_production_examples.rs
@@ -57,8 +57,6 @@ fn example8() {
 }
 
 #[test]
-#[ignore]
-// Doesn't handle special case of verb `a` as a replacement for `rdfs:type`
 fn example9() {
     triples_example_file("example9.ttl");
 }


### PR DESCRIPTION
Also fixes rendering of leading whitespace of base, which could have lead to #10 