### PR TITLE
Fix broken parsing of ObjectList without whitespace before comma

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -967,7 +967,8 @@ impl<'a> PrefixedName<'a> {
                 // (there are restrictions for first and last character)
                 opt(many1(satisfy(Self::is_pn_chars))),
                 char(':'),
-                opt(is_not(" \t\r\n")),
+                // TODO: proper implementation of PN_LOCAL
+                opt(is_not(" \t\r\n,")),
             )),
             |(prefix, _, name)| Self {
                 prefix: prefix.map(|chars| Cow::Owned(chars.into_iter().collect())),

--- a/tests/roundtrip_examples.rs
+++ b/tests/roundtrip_examples.rs
@@ -227,8 +227,6 @@ fn wildtype_rdfs_ontology() {
 }
 
 #[test]
-#[ignore]
-// TODO: Artifact with duplicate commas somewhere
 fn wildtype_owl_ontology() {
     roundtrip_wildtype_file("owl.ttl");
 }


### PR DESCRIPTION
Fixes OWL ontology wildtype roundtrip example